### PR TITLE
[JS] Optimization add basic README

### DIFF
--- a/ezmsg-js/README.md
+++ b/ezmsg-js/README.md
@@ -1,5 +1,9 @@
 # Installation
-_Coming soon_
+Currently only available via npm.
+
+For browser JS, run `npm i ezmsg-web`.
+
+For NodeJS, you can also use `ezmsg-web`, but it is recommended to use the NodeJS version by running `npm i ezmsg-node`.
 
 # Usage
 _Coming soon_

--- a/ezmsg-js/build-node/package.json
+++ b/ezmsg-js/build-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ezmsg-node",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "",
   "repository": {},
   "main": "dist/node/index.js",

--- a/ezmsg-js/build-web/package.json
+++ b/ezmsg-js/build-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ezmsg-web",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "",
   "repository": {},
   "main": "dist/web/index.js",

--- a/ezmsg-js/src/node/bbuffer.ts
+++ b/ezmsg-js/src/node/bbuffer.ts
@@ -45,20 +45,6 @@ export class BBuffer implements BBufferInterface {
     return Buffer.byteLength(value) + BSIZE[STR_SIZE_TYPE];
   };
 
-  slice(start = 0, end?: number): BBufferInterface {
-    const tmp = this.buffer.slice(start, end);
-
-    return BBuffer.from(tmp.buffer);
-  }
-
-  set(bBuffer: BBuffer, offset?: number) {
-    this.buffer.set(bBuffer.buffer, offset);
-  }
-
-  fill(buffer: Uint8Array, offset?: number) {
-    this.buffer.set(buffer, offset);
-  }
-
   write(type: BType, offset: number, value: BValue): number {
     if (type >= BType.U8 && type <= BType.F64) {
       this.buffer[`write${BFuncKey[type]}`](value as number, offset);

--- a/ezmsg-js/src/node/creators.ts
+++ b/ezmsg-js/src/node/creators.ts
@@ -2,5 +2,5 @@ import { BBuffer } from './bbuffer';
 import { createDeserializer } from '../shared/create-deserializer';
 import { createSerializer } from '../shared/create-serializer';
 
-export const serialize = createSerializer(BBuffer.create, BBuffer.calcStrSize);
+export const serialize = createSerializer(BBuffer.create);
 export const deserialize = createDeserializer(BBuffer.from);

--- a/ezmsg-js/src/node/index.ts
+++ b/ezmsg-js/src/node/index.ts
@@ -1,3 +1,2 @@
-export * from '../shared/types';
-export * from '../shared/constants';
-export * from './creators';
+export { BType } from '../shared/types';
+export { serialize, deserialize } from './creators';

--- a/ezmsg-js/src/shared/constants.ts
+++ b/ezmsg-js/src/shared/constants.ts
@@ -2,5 +2,6 @@ import { BType } from './types';
 
 export const BSIZE = [1, 2, 4, 1, 2, 4, 4, 8, 1, 0];
 
+export const INITIAL_BUFFER_SIZE = 128;
 export const MAX_SIZE_TYPE = BType.I32;
 export const STR_SIZE_TYPE = BType.I16;

--- a/ezmsg-js/src/shared/constants.ts
+++ b/ezmsg-js/src/shared/constants.ts
@@ -1,7 +1,12 @@
-import { BType } from './types';
-
 export const BSIZE = [1, 2, 4, 1, 2, 4, 4, 8, 1, 0];
 
 export const INITIAL_BUFFER_SIZE = 128;
-export const MAX_SIZE_TYPE = BType.I32;
-export const STR_SIZE_TYPE = BType.I16;
+
+export const BITS_PER_BYTE = 8;
+export const SIZE_COUNT_BIT = 3;
+export const BYTE_1_WITH_SIZE_REST = BITS_PER_BYTE - SIZE_COUNT_BIT;
+export const BYTE_2_WITH_SIZE_REST = BITS_PER_BYTE * 2 - SIZE_COUNT_BIT;
+export const BYTE_4_WITH_SIZE_REST = BITS_PER_BYTE * 4 - SIZE_COUNT_BIT;
+export const BYTE_1_WITH_SIZE_LIMIT = 1 << BYTE_1_WITH_SIZE_REST;
+export const BYTE_2_WITH_SIZE_LIMIT = 1 << BYTE_2_WITH_SIZE_REST;
+export const BYTE_4_WITH_SIZE_LIMIT = 1 << BYTE_4_WITH_SIZE_REST;

--- a/ezmsg-js/src/shared/create-deserializer.ts
+++ b/ezmsg-js/src/shared/create-deserializer.ts
@@ -10,7 +10,6 @@ import {
   BValueArray,
   BValueObject
 } from './types';
-import { MAX_SIZE_TYPE } from './constants';
 
 function deserializeArray(
   buffer: BBufferInterface,
@@ -19,7 +18,7 @@ function deserializeArray(
 ): [BValueArray, number] {
   let currentOffset = offset;
 
-  const [size, typeSize] = buffer.read(MAX_SIZE_TYPE, currentOffset);
+  const [size, typeSize] = buffer.readSize(currentOffset);
   currentOffset += typeSize;
 
   const result = [];
@@ -41,7 +40,7 @@ function deserializeObject(
 ): [BValueObject, number] {
   let currentOffset = offset;
 
-  const [size, typeSize] = buffer.read(MAX_SIZE_TYPE, currentOffset);
+  const [size, typeSize] = buffer.readSize(currentOffset);
 
   if (size === 0) return [null, typeSize];
 

--- a/ezmsg-js/src/shared/create-deserializer.ts
+++ b/ezmsg-js/src/shared/create-deserializer.ts
@@ -10,6 +10,7 @@ import {
   BValueArray,
   BValueObject
 } from './types';
+import { readSize } from './utils';
 
 function deserializeArray(
   buffer: BBufferInterface,
@@ -18,7 +19,7 @@ function deserializeArray(
 ): [BValueArray, number] {
   let currentOffset = offset;
 
-  const [size, typeSize] = buffer.readSize(currentOffset);
+  const [size, typeSize] = readSize(buffer, currentOffset);
   currentOffset += typeSize;
 
   const result = [];
@@ -40,7 +41,7 @@ function deserializeObject(
 ): [BValueObject, number] {
   let currentOffset = offset;
 
-  const [size, typeSize] = buffer.readSize(currentOffset);
+  const [size, typeSize] = readSize(buffer, currentOffset);
 
   if (size === 0) return [null, typeSize];
 

--- a/ezmsg-js/src/shared/create-serializer.ts
+++ b/ezmsg-js/src/shared/create-serializer.ts
@@ -12,6 +12,7 @@ import {
   BTypeArray
 } from './types';
 import { INITIAL_BUFFER_SIZE } from './constants';
+import { writeSize } from './utils';
 
 function serializeArray(
   buffer: BBufferInterface,
@@ -21,7 +22,7 @@ function serializeArray(
 ): number {
   let currentOffset = offset;
 
-  currentOffset += buffer.writeSize(currentOffset, value.length);
+  currentOffset += writeSize(buffer, currentOffset, value.length);
 
   value.forEach(v => {
     currentOffset += serializeValue(buffer, v, type[0], currentOffset);
@@ -39,7 +40,7 @@ function serializeObject(
   let currentOffset = offset;
   const keys = Object.keys(type);
 
-  const typeSize = buffer.writeSize(currentOffset, value ? keys.length : 0);
+  const typeSize = writeSize(buffer, currentOffset, value ? keys.length : 0);
 
   if (!value) return typeSize;
 

--- a/ezmsg-js/src/shared/create-serializer.ts
+++ b/ezmsg-js/src/shared/create-serializer.ts
@@ -11,7 +11,7 @@ import {
   BTypeObject,
   BTypeArray
 } from './types';
-import { MAX_SIZE_TYPE, INITIAL_BUFFER_SIZE } from './constants';
+import { INITIAL_BUFFER_SIZE } from './constants';
 
 function serializeArray(
   buffer: BBufferInterface,
@@ -21,7 +21,7 @@ function serializeArray(
 ): number {
   let currentOffset = offset;
 
-  currentOffset += buffer.write(MAX_SIZE_TYPE, currentOffset, value.length);
+  currentOffset += buffer.writeSize(currentOffset, value.length);
 
   value.forEach(v => {
     currentOffset += serializeValue(buffer, v, type[0], currentOffset);
@@ -39,11 +39,7 @@ function serializeObject(
   let currentOffset = offset;
   const keys = Object.keys(type);
 
-  const typeSize = buffer.write(
-    MAX_SIZE_TYPE,
-    currentOffset,
-    value ? keys.length : 0
-  );
+  const typeSize = buffer.writeSize(currentOffset, value ? keys.length : 0);
 
   if (!value) return typeSize;
 
@@ -88,7 +84,6 @@ export const createSerializer: CreateSerializerFunc = (
 ) => {
   return (value: BValueParam, type: BTypeParam) => {
     const buffer = createNewBuffer(INITIAL_BUFFER_SIZE);
-
     const size = serializeValue(buffer, value, type);
 
     return buffer.toArrayBuffer().slice(0, size);

--- a/ezmsg-js/src/shared/create-serializer.ts
+++ b/ezmsg-js/src/shared/create-serializer.ts
@@ -9,10 +9,9 @@ import {
   BBufferInterface,
   BValue,
   BTypeObject,
-  BTypeArray,
-  CalcStrSizeFunc
+  BTypeArray
 } from './types';
-import { BSIZE, MAX_SIZE_TYPE } from './constants';
+import { MAX_SIZE_TYPE, INITIAL_BUFFER_SIZE } from './constants';
 
 function serializeArray(
   buffer: BBufferInterface,
@@ -84,43 +83,14 @@ function serializeValue(
   );
 }
 
-function countBufferSize(
-  value: BValueParam,
-  type: BTypeParam,
-  calcStrSize: CalcStrSizeFunc
-) {
-  if (!(typeof type === 'object')) {
-    if (type !== BType.STR) return BSIZE[type as BType];
-
-    return calcStrSize(value as string);
-  }
-
-  if (type.constructor === Array) {
-    return (value as BValueArray).reduce(
-      (acc, v) => acc + countBufferSize(v, type[0], calcStrSize),
-      BSIZE[MAX_SIZE_TYPE]
-    );
-  }
-
-  if (!value) return MAX_SIZE_TYPE;
-
-  return Object.keys(type as BValueObject).reduce(
-    (acc, k) => acc + countBufferSize(value[k], type[k], calcStrSize),
-    BSIZE[MAX_SIZE_TYPE]
-  );
-}
-
 export const createSerializer: CreateSerializerFunc = (
-  createNewBuffer: CreateNewBufferFunc,
-  calcStrSize: CalcStrSizeFunc
+  createNewBuffer: CreateNewBufferFunc
 ) => {
   return (value: BValueParam, type: BTypeParam) => {
-    const bufferSize = countBufferSize(value, type, calcStrSize);
+    const buffer = createNewBuffer(INITIAL_BUFFER_SIZE);
 
-    const buffer = createNewBuffer(bufferSize);
+    const size = serializeValue(buffer, value, type);
 
-    serializeValue(buffer, value, type);
-
-    return buffer.toArrayBuffer();
+    return buffer.toArrayBuffer().slice(0, size);
   };
 };

--- a/ezmsg-js/src/shared/types.ts
+++ b/ezmsg-js/src/shared/types.ts
@@ -27,9 +27,7 @@ export interface BTypeObject {
 
 export interface BBufferInterface {
   write: (type: BType, offset: number, value: BValue) => number;
-  writeSize: (offset: number, size: number) => number;
   read: (type: BType, offset: number) => [BValue, number];
-  readSize: (offset) => [number, number];
   toArrayBuffer: () => ArrayBuffer;
   expand: (neededSize: number) => void;
 }

--- a/ezmsg-js/src/shared/types.ts
+++ b/ezmsg-js/src/shared/types.ts
@@ -29,6 +29,7 @@ export interface BBufferInterface {
   write: (type: BType, offset: number, value: BValue) => number;
   read: (type: BType, offset: number) => [BValue, number];
   toArrayBuffer: () => ArrayBuffer;
+  expand: (neededSize: number) => void;
 }
 
 export type CreateNewBufferFunc = (size: number) => BBufferInterface;
@@ -36,8 +37,6 @@ export type CreateNewBufferFunc = (size: number) => BBufferInterface;
 export type CreateBufferFromFunc = (
   arrayBuffer: ArrayBuffer
 ) => BBufferInterface;
-
-export type CalcStrSizeFunc = (value: string) => number;
 
 export type SerializeFunc = (
   value: BValueParam,
@@ -50,8 +49,7 @@ export type DeserializeFunc = (
 ) => BValueParam;
 
 export type CreateSerializerFunc = (
-  createNewBuffer: CreateNewBufferFunc,
-  calcStrSize: CalcStrSizeFunc
+  createNewBuffer: CreateNewBufferFunc
 ) => SerializeFunc;
 
 export type CreateDeserializerFunc = (

--- a/ezmsg-js/src/shared/types.ts
+++ b/ezmsg-js/src/shared/types.ts
@@ -29,9 +29,6 @@ export interface BBufferInterface {
   write: (type: BType, offset: number, value: BValue) => number;
   read: (type: BType, offset: number) => [BValue, number];
   toArrayBuffer: () => ArrayBuffer;
-  slice: (start?: number, end?: number) => BBufferInterface;
-  set: (bBuffer: BBufferInterface, offset?: number) => void;
-  fill: (buffer: Uint8Array, offset?: number) => void;
 }
 
 export type CreateNewBufferFunc = (size: number) => BBufferInterface;

--- a/ezmsg-js/src/shared/types.ts
+++ b/ezmsg-js/src/shared/types.ts
@@ -27,7 +27,9 @@ export interface BTypeObject {
 
 export interface BBufferInterface {
   write: (type: BType, offset: number, value: BValue) => number;
+  writeSize: (offset: number, size: number) => number;
   read: (type: BType, offset: number) => [BValue, number];
+  readSize: (offset) => [number, number];
   toArrayBuffer: () => ArrayBuffer;
   expand: (neededSize: number) => void;
 }

--- a/ezmsg-js/src/shared/utils.ts
+++ b/ezmsg-js/src/shared/utils.ts
@@ -1,3 +1,14 @@
+import { BBufferInterface, BType } from './types';
+import {
+  BITS_PER_BYTE,
+  SIZE_COUNT_BIT,
+  BYTE_1_WITH_SIZE_LIMIT,
+  BYTE_2_WITH_SIZE_LIMIT,
+  BYTE_1_WITH_SIZE_REST,
+  BYTE_2_WITH_SIZE_REST,
+  BYTE_4_WITH_SIZE_REST
+} from '../shared/constants';
+
 export function nextPowerOf2(value: number): number {
   if (value <= 0) return 1;
 
@@ -12,4 +23,41 @@ export function nextPowerOf2(value: number): number {
   result++;
 
   return result;
+}
+
+export function writeSize(
+  bBuffer: BBufferInterface,
+  offset: number,
+  size: number
+): number {
+  if (size < BYTE_1_WITH_SIZE_LIMIT) {
+    const writeVal = (1 << BYTE_1_WITH_SIZE_REST) | size;
+    return bBuffer.write(BType.U8, offset, writeVal);
+  }
+
+  if (size < BYTE_2_WITH_SIZE_LIMIT) {
+    const writeVal = (2 << BYTE_2_WITH_SIZE_REST) | size;
+    return bBuffer.write(BType.U16, offset, writeVal);
+  }
+
+  const writeVal = (4 << BYTE_4_WITH_SIZE_REST) | size;
+  return bBuffer.write(BType.U32, offset, writeVal);
+}
+
+export function readSize(
+  bBuffer: BBufferInterface,
+  offset: number
+): [number, number] {
+  const [firstByteValue] = bBuffer.read(BType.U8, offset);
+  const byteSize = (firstByteValue as number) >> BYTE_1_WITH_SIZE_REST;
+
+  const type =
+    byteSize === 1 ? BType.U8 : byteSize === 2 ? BType.U16 : BType.U32;
+
+  const [readVal, size] = bBuffer.read(type, offset);
+  const value =
+    (readVal as number) &
+    ((1 << (byteSize * BITS_PER_BYTE - SIZE_COUNT_BIT)) - 1);
+
+  return [value, size];
 }

--- a/ezmsg-js/src/web/bbuffer.ts
+++ b/ezmsg-js/src/web/bbuffer.ts
@@ -56,18 +56,6 @@ export class BBuffer implements BBufferInterface {
     return s + BSIZE[STR_SIZE_TYPE];
   };
 
-  slice(start = 0, end?: number): BBufferInterface {
-    return BBuffer.from(this.arr.slice(start, end));
-  }
-
-  set(bBuffer: BBuffer, offset?: number) {
-    this.arr.set(bBuffer.arr, offset);
-  }
-
-  fill(buffer: Uint8Array, offset?: number) {
-    this.arr.set(buffer, offset);
-  }
-
   write(type: BType, offset: number, value: BValue): number {
     if (type >= BType.U8 && type <= BType.F64) {
       this.dv[`set${BFuncKey[type]}`](offset, value as number);
@@ -83,7 +71,7 @@ export class BBuffer implements BBufferInterface {
 
       const typeSize = this.write(STR_SIZE_TYPE, offset, valueSize);
 
-      this.fill(encoded, offset + typeSize);
+      this.arr.set(encoded, offset + typeSize);
 
       return typeSize + valueSize;
     }

--- a/ezmsg-js/src/web/bbuffer.ts
+++ b/ezmsg-js/src/web/bbuffer.ts
@@ -5,17 +5,8 @@ import {
   CreateNewBufferFunc,
   CreateBufferFromFunc
 } from '../shared/types';
-import {
-  BSIZE,
-  BITS_PER_BYTE,
-  SIZE_COUNT_BIT,
-  BYTE_1_WITH_SIZE_LIMIT,
-  BYTE_2_WITH_SIZE_LIMIT,
-  BYTE_1_WITH_SIZE_REST,
-  BYTE_2_WITH_SIZE_REST,
-  BYTE_4_WITH_SIZE_REST
-} from '../shared/constants';
-import { nextPowerOf2 } from '../shared/utils';
+import { BSIZE } from '../shared/constants';
+import { nextPowerOf2, writeSize, readSize } from '../shared/utils';
 
 const BFuncKey = [
   'Uint8',
@@ -67,36 +58,6 @@ export class BBuffer implements BBufferInterface {
     this.dv = newDV;
   }
 
-  writeSize(offset: number, size: number): number {
-    if (size < BYTE_1_WITH_SIZE_LIMIT) {
-      const writeVal = (1 << BYTE_1_WITH_SIZE_REST) | size;
-      return this.write(BType.U8, offset, writeVal);
-    }
-
-    if (size < BYTE_2_WITH_SIZE_LIMIT) {
-      const writeVal = (2 << BYTE_2_WITH_SIZE_REST) | size;
-      return this.write(BType.U16, offset, writeVal);
-    }
-
-    const writeVal = (4 << BYTE_4_WITH_SIZE_REST) | size;
-    return this.write(BType.U32, offset, writeVal);
-  }
-
-  readSize(offset): [number, number] {
-    const [firstByteValue] = this.read(BType.U8, offset);
-    const byteSize = (firstByteValue as number) >> BYTE_1_WITH_SIZE_REST;
-
-    const type =
-      byteSize === 1 ? BType.U8 : byteSize === 2 ? BType.U16 : BType.U32;
-
-    const [readVal, size] = this.read(type, offset);
-    const value =
-      (readVal as number) &
-      ((1 << (byteSize * BITS_PER_BYTE - SIZE_COUNT_BIT)) - 1);
-
-    return [value, size];
-  }
-
   write(type: BType, offset: number, value: BValue): number {
     if (type >= BType.U8 && type <= BType.F64) {
       this.expand(offset + BSIZE[type]);
@@ -112,7 +73,7 @@ export class BBuffer implements BBufferInterface {
       const encoded = encoder.encode(value as string);
 
       const valueSize = encoded.byteLength;
-      const typeSize = this.writeSize(offset, valueSize);
+      const typeSize = writeSize(this, offset, valueSize);
 
       this.expand(offset + valueSize + typeSize);
       this.arr.set(encoded, offset + typeSize);
@@ -127,7 +88,7 @@ export class BBuffer implements BBufferInterface {
     } else if (type === BType.BOOL) {
       return [this.dv[`get${BFuncKey[type]}`](offset) > 0, BSIZE[type]];
     } else if (type === BType.STR) {
-      const [valueSize, typeSize] = this.readSize(offset);
+      const [valueSize, typeSize] = readSize(this, offset);
       const dataOffset = offset + typeSize;
 
       const result = decoder.decode(

--- a/ezmsg-js/src/web/bbuffer.ts
+++ b/ezmsg-js/src/web/bbuffer.ts
@@ -5,7 +5,16 @@ import {
   CreateNewBufferFunc,
   CreateBufferFromFunc
 } from '../shared/types';
-import { STR_SIZE_TYPE, BSIZE } from '../shared/constants';
+import {
+  BSIZE,
+  BITS_PER_BYTE,
+  SIZE_COUNT_BIT,
+  BYTE_1_WITH_SIZE_LIMIT,
+  BYTE_2_WITH_SIZE_LIMIT,
+  BYTE_1_WITH_SIZE_REST,
+  BYTE_2_WITH_SIZE_REST,
+  BYTE_4_WITH_SIZE_REST
+} from '../shared/constants';
 import { nextPowerOf2 } from '../shared/utils';
 
 const BFuncKey = [
@@ -58,6 +67,36 @@ export class BBuffer implements BBufferInterface {
     this.dv = newDV;
   }
 
+  writeSize(offset: number, size: number): number {
+    if (size < BYTE_1_WITH_SIZE_LIMIT) {
+      const writeVal = (1 << BYTE_1_WITH_SIZE_REST) | size;
+      return this.write(BType.U8, offset, writeVal);
+    }
+
+    if (size < BYTE_2_WITH_SIZE_LIMIT) {
+      const writeVal = (2 << BYTE_2_WITH_SIZE_REST) | size;
+      return this.write(BType.U16, offset, writeVal);
+    }
+
+    const writeVal = (4 << BYTE_4_WITH_SIZE_REST) | size;
+    return this.write(BType.U32, offset, writeVal);
+  }
+
+  readSize(offset): [number, number] {
+    const [firstByteValue] = this.read(BType.U8, offset);
+    const byteSize = (firstByteValue as number) >> BYTE_1_WITH_SIZE_REST;
+
+    const type =
+      byteSize === 1 ? BType.U8 : byteSize === 2 ? BType.U16 : BType.U32;
+
+    const [readVal, size] = this.read(type, offset);
+    const value =
+      (readVal as number) &
+      ((1 << (byteSize * BITS_PER_BYTE - SIZE_COUNT_BIT)) - 1);
+
+    return [value, size];
+  }
+
   write(type: BType, offset: number, value: BValue): number {
     if (type >= BType.U8 && type <= BType.F64) {
       this.expand(offset + BSIZE[type]);
@@ -71,11 +110,11 @@ export class BBuffer implements BBufferInterface {
       return BSIZE[type];
     } else if (type === BType.STR) {
       const encoded = encoder.encode(value as string);
+
       const valueSize = encoded.byteLength;
-      const typeSize = BSIZE[STR_SIZE_TYPE];
+      const typeSize = this.writeSize(offset, valueSize);
 
       this.expand(offset + valueSize + typeSize);
-      this.write(STR_SIZE_TYPE, offset, valueSize);
       this.arr.set(encoded, offset + typeSize);
 
       return typeSize + valueSize;
@@ -88,7 +127,7 @@ export class BBuffer implements BBufferInterface {
     } else if (type === BType.BOOL) {
       return [this.dv[`get${BFuncKey[type]}`](offset) > 0, BSIZE[type]];
     } else if (type === BType.STR) {
-      const [valueSize, typeSize] = this.read(STR_SIZE_TYPE, offset);
+      const [valueSize, typeSize] = this.readSize(offset);
       const dataOffset = offset + typeSize;
 
       const result = decoder.decode(

--- a/ezmsg-js/src/web/creators.ts
+++ b/ezmsg-js/src/web/creators.ts
@@ -2,5 +2,5 @@ import { BBuffer } from './bbuffer';
 import { createDeserializer } from '../shared/create-deserializer';
 import { createSerializer } from '../shared/create-serializer';
 
-export const serialize = createSerializer(BBuffer.create, BBuffer.calcStrSize);
+export const serialize = createSerializer(BBuffer.create);
 export const deserialize = createDeserializer(BBuffer.from);

--- a/ezmsg-js/src/web/index.ts
+++ b/ezmsg-js/src/web/index.ts
@@ -1,3 +1,2 @@
-export * from '../shared/types';
-export * from '../shared/constants';
-export * from './creators';
+export { BType } from '../shared/types';
+export { serialize, deserialize } from './creators';


### PR DESCRIPTION
- When serializing, do not count the needed buffer size at the beginning, but instead just expand the buffer's size when needed. This increase the performance of the web version, because counting the byte size of a string is quite expensive.

- For size bytes (string size, object keys length, and array length), it is now more compact, like for example if an array has 5 elements, the length of 5 will be written as only 1 byte in the resulting buffer, instead of fixed size of 4 bytes previously. I am ready to sacrifice a little bit of runtime performance for this, but when I tried to run the benchmark, this actually increase the runtime performance! And actually the increase is quite significant in the node version. I don't know why.